### PR TITLE
build: :arrow_up: use node 20 for ci and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@main
       - uses: actions/setup-node@v4
         with:
-          node-version: "16.x"
+          node-version: "20.x"
       - run: npm ci
       # - run: npm run build --if-present
       - run: npm test


### PR DESCRIPTION
Requires Node 20 and Directus SDK instead of nuxt-directus