### PR TITLE
ci: :building_construction: update semantic release rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,14 @@
         {
           "releaseRules": [
             {
+              "breaking": true,
+              "release": "major"
+            },
+            {
+              "type": "feat",
+              "release": "minor"
+            },
+            {
               "type": "revert",
               "release": "patch"
             },
@@ -76,6 +84,15 @@
             },
             {
               "type": "fix",
+              "release": "patch"
+            },
+            {
+              "type": "docs",
+              "scope": "README",
+              "release": "patch"
+            },
+            {
+              "type": "chore",
               "release": "patch"
             }
           ]


### PR DESCRIPTION
Requires Node 20 and Directus SDK instead of nuxt-directus